### PR TITLE
Add ability to set host in server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
+NODE_ENV=development
+
 TH_SESSION_SECRET=ashdfjhasdlkjfhalksdjhflak
 
+TH_API_HOST=localhost
 TH_API_PORT=8085
 
 TH_DB_NAME=TheaterHub

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     links:
       - db
     ports:
-      - "127.0.0.1:$TH_API_PORT:$TH_API_PORT"
+      - "$TH_API_PORT:$TH_API_PORT"
     depends_on:
       - db
     env_file: .env

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,6 +49,7 @@ if (cluster.isMaster) {
      * Express configuration.
      */
 
+    app.set("host", process.env.TH_API_HOST);
     app.set("port", process.env.TH_API_PORT);
     app.set("models", models);
     app.use(compression());
@@ -103,8 +104,8 @@ if (cluster.isMaster) {
     //   console.log("  Press CTRL-C to stop\n");
     // });
 
-    app.listen(app.get("port"), () => {
-      console.log(("  App is running at http://localhost:%d in %s mode"), app.get("port"), app.get("env"));
+    app.listen(app.get("port"), app.get("host"), () => {
+      console.log(("  App is running at http://%s:%d in %s mode"), app.get("host"), app.get("port"), app.get("env"));
       console.log("  Press CTRL-C to stop\n");
     });
 


### PR DESCRIPTION
### What does it fix?
This allows us to set "localhost" in development and "0.0.0.0" in
production.

### How has it been tested?
I tested it locally by running 
```
docker-compose --env-file .env build
docker-compose --env-file .env up
```

Values in `.env` for host, port and env were picked up by the server.
